### PR TITLE
Disable interrupts when calling IAP

### DIFF
--- a/W7500x_Library_Examples/Libraries/W7500x_stdPeriph_Driver/inc/W7500x_wztoe.h
+++ b/W7500x_Library_Examples/Libraries/W7500x_stdPeriph_Driver/inc/W7500x_wztoe.h
@@ -931,7 +931,7 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
  * @brief Set @ref Sn_DHAR register
  * @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
  * @param (uint8_t*)dhar Pointer variable to set socket n destination hardware address. It should be allocated 6 bytes.
- * @sa getSn_DHAR()
+ * @sa setSn_DHAR()
  */
 #define setSn_DHAR(sn, dhar) \
     WIZCHIP_WRITE((WZTOE_Sn_DHAR(sn)+3), dhar[0]); \
@@ -943,10 +943,10 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
 
 /**
  * @ingroup Socket_register_access_function
- * @brief Get @ref Sn_MR register
+ * @brief Get @ref Sn_DHAR register
  * @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
  * @param (uint8_t*)dhar Pointer variable to get socket n destination hardware address. It should be allocated 6 bytes.
- * @sa setSn_DHAR()
+ * @sa getSn_DHAR()
  */
  //15.05.19 by justinKim
 #define getSn_DHAR(sn, dhar) \
@@ -1110,18 +1110,18 @@ uipr[3] = WIZCHIP_READ((WZTOE_UIPR));
 
 /**
  * @ingroup Socket_register_access_function
- * @brief Get @ref Sn_RX_RD register
+ * @brief Set @ref Sn_RX_RD register
  * @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
- * @regurn uint16_t. Value of @ref Sn_RX_RD.
+ * @param (uint16_t)rxrd Value to set @ref Sn_RX_RD
  * @sa setSn_RX_RD()
  */
 #define setSn_RX_RD(sn, rxrd) (*(volatile uint32_t *)(WZTOE_Sn_RX_RD(sn)) = rxrd)
 
 /**
  * @ingroup Socket_register_access_function
- * @brief Set @ref Sn_RX_RD register
+ * @brief Get @ref Sn_RX_RD register
  * @param (uint8_t)sn Socket number. It should be <b>0 ~ 7</b>.
- * @param (uint16_t)rxrd Value to set @ref Sn_RX_RD
+ * @return uint16_t. Value of @ref Sn_RX_RD.
  * @sa getSn_RX_RD()
  */
 #define getSn_RX_RD(sn)  ((uint16_t)(*(volatile uint32_t *)(WZTOE_Sn_RX_RD(sn))))

--- a/W7500x_Library_Examples/Projects/Peripheral_Examples/Flash/IAP_Example/main.c
+++ b/W7500x_Library_Examples/Projects/Peripheral_Examples/Flash/IAP_Example/main.c
@@ -131,17 +131,14 @@ int main()
   */
 void DO_IAP( uint32_t id, uint32_t dst_addr, uint8_t* src_addr, uint32_t size)
 {
-    uint32_t temp_interrupt;
-
-    // Backup Interrupt Set Pending Register
-    temp_interrupt = (NVIC->ISPR[0]);
-    (NVIC->ISPR[0]) = (uint32_t)0xFFFFFFFF;
+    // Disable interrupts before calling IAP
+    __disable_irq();
     
     // Call IAP Function
     ((void(*)(uint32_t,uint32_t,uint8_t*,uint32_t))IAP_ENTRY)( id,dst_addr,src_addr,size);
 
-    // Restore Interrupt Set Pending Register
-    (NVIC->ISPR[0]) = temp_interrupt;
+    // Enable interrupts
+    __enable_irq();
 }
 
 /**

--- a/W7500x_Library_Examples/ioLibrary/Internet/httpServer/httpParser.c
+++ b/W7500x_Library_Examples/ioLibrary/Internet/httpServer/httpParser.c
@@ -164,7 +164,7 @@ void parse_http_request(
     request->METHOD = METHOD_ERR;
     return;
   }
-  strcpy((char *)request->URI, nexttok);
+  strncpy((char *)request->URI, nexttok, MAX_URI_SIZE);
 }
 
 #ifdef _OLD_

--- a/W7500x_Library_Examples/ioLibrary/Internet/httpServer/httpServer.c
+++ b/W7500x_Library_Examples/ioLibrary/Internet/httpServer/httpServer.c
@@ -21,7 +21,7 @@
 /*****************************************************************************
  * Private types/enumerations/variables
  ****************************************************************************/
-static uint8_t HTTPSock_Num[_WIZCHIP_SOCK_NUM_] = {0, };
+static uint8_t HTTPSock_Num[_WIZCHIP_SOCK_NUM_];
 static st_http_request * http_request;				/**< Pointer to received HTTP request */
 static st_http_request * parsed_http_request;		/**< Pointer to parsed HTTP request */
 static uint8_t * http_response;						/**< Pointer to HTTP response */
@@ -30,15 +30,15 @@ static uint8_t * http_response;						/**< Pointer to HTTP response */
 //static uint8_t uri_buf[128];
 
 // Number of registered web content in code flash memory
-static uint16_t total_content_cnt = 0;
+static uint16_t total_content_cnt;
 /*****************************************************************************
  * Public types/enumerations/variables
  ****************************************************************************/
 uint8_t * pHTTP_TX;
 uint8_t * pHTTP_RX;
 
-volatile uint32_t httpServer_tick_1s = 0;
-st_http_socket HTTPSock_Status[_WIZCHIP_SOCK_NUM_] = { {STATE_HTTP_IDLE, }, };
+volatile uint32_t httpServer_tick_1s;
+st_http_socket HTTPSock_Status[_WIZCHIP_SOCK_NUM_];
 httpServer_webContent web_content[MAX_CONTENT_CALLBACK];
 
 #ifdef	_USE_SDCARD_
@@ -97,6 +97,20 @@ static int8_t getHTTPSequenceNum(uint8_t socket)
 
 void httpServer_init(uint8_t * tx_buf, uint8_t * rx_buf, uint8_t cnt, uint8_t * socklist)
 {
+	int i;
+	
+	total_content_cnt  = 0;
+	httpServer_tick_1s = 0;
+	for (i = 0; i < _WIZCHIP_SOCK_NUM_; i++)
+	{
+		HTTPSock_Num[i] = 0;
+		
+		memset(&HTTPSock_Status[i], 0, sizeof(st_http_socket));
+		HTTPSock_Status[i].sock_status = STATE_HTTP_IDLE;
+	}
+	HTTPServer_ReStart   = default_mcu_reset;
+	HTTPServer_WDT_Reset = default_wdt_reset;
+	
 	// User's shared buffer
 	pHTTP_TX = tx_buf;
 	pHTTP_RX = rx_buf;


### PR DESCRIPTION
If an interrupt occurs during flash write this can produce an error (tested with systick). This patch allow to disable/enable interrupts during IAP call
